### PR TITLE
Fix mixed content scheme with proxy issue

### DIFF
--- a/src/main/scala/ThreedRenderer.scala
+++ b/src/main/scala/ThreedRenderer.scala
@@ -50,7 +50,7 @@ class ThreedRenderer extends Renderer {
       s"""
          |<script>
          |  function myrender() {
-         |    init("${context.request.getRequestURL + "?raw=true"}", document.getElementById("stl-viewer"), document.getElementsByName("stl-options"))
+         |    init("${context.currentPath + "?raw=true"}", document.getElementById("stl-viewer"), document.getElementsByName("stl-options"))
          |  }
          |</script>
          |""".stripMargin


### PR DESCRIPTION
Use just the `currentPath` to the raw STL to avoid proxy HTTP/HTTPS issues.